### PR TITLE
Adding metadata  to CC

### DIFF
--- a/contracts/ColuLocalCurrency.sol
+++ b/contracts/ColuLocalCurrency.sol
@@ -14,7 +14,7 @@ contract ColuLocalCurrency is Ownable, Standard677Token, TokenHolder {
     uint8 public decimals;
     string public tokenURI;
 
-    event TokenURIChanged(string tokenURI);
+    event TokenURIChanged(string newTokenURI);
 
     /// @dev cotract to use when issuing a CC (Local Currency)
     /// @param _name string name for CC token that is created.

--- a/contracts/ColuLocalCurrency.sol
+++ b/contracts/ColuLocalCurrency.sol
@@ -12,14 +12,15 @@ contract ColuLocalCurrency is Ownable, Standard677Token, TokenHolder {
     string public name;
     string public symbol;
     uint8 public decimals;
-   
+    string public metadata;
+
     /// @dev cotract to use when issuing a CC (Local Currency)
     /// @param _name string name for CC token that is created.
     /// @param _symbol string symbol for CC token that is created.
     /// @param _decimals uint8 percison for CC token that is created.
-    /// @param _totalSupply uint256 total supply of the CC token that is created. 
-    function ColuLocalCurrency(string _name, string _symbol, uint8 _decimals, uint256 _totalSupply) public {
-        require(_totalSupply != 0);     
+    /// @param _totalSupply uint256 total supply of the CC token that is created.
+    function ColuLocalCurrency(string _name, string _symbol, uint8 _decimals, uint256 _totalSupply, string _metadata) public {
+        require(_totalSupply != 0);
         require(bytes(_name).length != 0);
         require(bytes(_symbol).length != 0);
 
@@ -27,6 +28,7 @@ contract ColuLocalCurrency is Ownable, Standard677Token, TokenHolder {
         name = _name;
         symbol = _symbol;
         decimals = _decimals;
+        metadata = _metadata;
         balances[msg.sender] = totalSupply;
     }
 }

--- a/contracts/ColuLocalCurrency.sol
+++ b/contracts/ColuLocalCurrency.sol
@@ -21,6 +21,7 @@ contract ColuLocalCurrency is Ownable, Standard677Token, TokenHolder {
     /// @param _symbol string symbol for CC token that is created.
     /// @param _decimals uint8 percison for CC token that is created.
     /// @param _totalSupply uint256 total supply of the CC token that is created.
+    /// @param _metadata string hash of the metadata of the token
     function ColuLocalCurrency(string _name, string _symbol, uint8 _decimals, uint256 _totalSupply, string _metadata) public {
         require(_totalSupply != 0);
         require(bytes(_name).length != 0);

--- a/contracts/ColuLocalCurrency.sol
+++ b/contracts/ColuLocalCurrency.sol
@@ -14,6 +14,8 @@ contract ColuLocalCurrency is Ownable, Standard677Token, TokenHolder {
     uint8 public decimals;
     string public metadata;
 
+    event MetadataChanged(string metadata);
+
     /// @dev cotract to use when issuing a CC (Local Currency)
     /// @param _name string name for CC token that is created.
     /// @param _symbol string symbol for CC token that is created.
@@ -30,5 +32,10 @@ contract ColuLocalCurrency is Ownable, Standard677Token, TokenHolder {
         decimals = _decimals;
         metadata = _metadata;
         balances[msg.sender] = totalSupply;
+    }
+
+    function setMetadata(string _metadata) public onlyOwner {
+      metadata = _metadata;
+      MetadataChanged(_metadata);
     }
 }

--- a/contracts/ColuLocalCurrency.sol
+++ b/contracts/ColuLocalCurrency.sol
@@ -12,17 +12,17 @@ contract ColuLocalCurrency is Ownable, Standard677Token, TokenHolder {
     string public name;
     string public symbol;
     uint8 public decimals;
-    string public metadata;
+    string public tokenURI;
 
-    event MetadataChanged(string metadata);
+    event TokenURIChanged(string tokenURI);
 
     /// @dev cotract to use when issuing a CC (Local Currency)
     /// @param _name string name for CC token that is created.
     /// @param _symbol string symbol for CC token that is created.
     /// @param _decimals uint8 percison for CC token that is created.
     /// @param _totalSupply uint256 total supply of the CC token that is created.
-    /// @param _metadata string hash of the metadata of the token
-    function ColuLocalCurrency(string _name, string _symbol, uint8 _decimals, uint256 _totalSupply, string _metadata) public {
+    /// @param _tokenURI string the URI may point to a JSON file that conforms to the "Metadata JSON Schema".
+    function ColuLocalCurrency(string _name, string _symbol, uint8 _decimals, uint256 _totalSupply, string _tokenURI) public {
         require(_totalSupply != 0);
         require(bytes(_name).length != 0);
         require(bytes(_symbol).length != 0);
@@ -31,12 +31,14 @@ contract ColuLocalCurrency is Ownable, Standard677Token, TokenHolder {
         name = _name;
         symbol = _symbol;
         decimals = _decimals;
-        metadata = _metadata;
+        tokenURI = _tokenURI;
         balances[msg.sender] = totalSupply;
     }
 
-    function setMetadata(string _metadata) public onlyOwner {
-      metadata = _metadata;
-      MetadataChanged(_metadata);
+    /// @dev Sets the tokenURI field, can be called by the owner only
+    /// @param _tokenURI string the URI may point to a JSON file that conforms to the "Metadata JSON Schema".
+    function setTokenURI(string _tokenURI) public onlyOwner {
+      tokenURI = _tokenURI;
+      TokenURIChanged(_tokenURI);
     }
 }

--- a/contracts/CurrencyFactory.sol
+++ b/contracts/CurrencyFactory.sol
@@ -72,7 +72,7 @@ contract CurrencyFactory is Standard223Receiver, TokenHolder {
   /// @param _symbol string symbol for CC token that is created.
   /// @param _decimals uint8 percison for CC token that is created.
   /// @param _totalSupply uint256 total supply of the CC token that is created.
-  /// @param _tokenURI string IPFS hash for the CC token data.
+  /// @param _tokenURI string the URI may point to a JSON file that conforms to the "Metadata JSON Schema".
   function createCurrency(string _name,
                           string _symbol,
                           uint8 _decimals,
@@ -168,10 +168,9 @@ contract CurrencyFactory is Standard223Receiver, TokenHolder {
   	return (clnAddress == _token || currencyMap[_token].totalSupply > 0);
   }
 
-  /// @dev sets tokenURI for the given currency, can be used only during the sell only
+  /// @dev sets tokenURI for the given currency, can be used during the sell only
   /// @param _token address address of the token to update
-  /// @param _tokenURI string hash of the metadata of the token, this
-  /// hash can be accessed through IPFS
+  /// @param _tokenURI string the URI may point to a JSON file that conforms to the "Metadata JSON Schema".
   function setTokenURI(address _token, string _tokenURI) public
                               tokenIssuerOnly(_token, msg.sender)
                               marketClosed(_token)

--- a/contracts/CurrencyFactory.sol
+++ b/contracts/CurrencyFactory.sol
@@ -31,7 +31,6 @@ contract CurrencyFactory is Standard223Receiver, TokenHolder {
 
   event MarketOpen(address indexed marketMaker);
   event TokenCreated(address indexed token, address indexed owner);
-  event TokenDataChanged(address indexed token, string data);
 
   // modifier to check if called by issuer of the token
   modifier tokenIssuerOnly(address token, address owner) {
@@ -154,21 +153,16 @@ contract CurrencyFactory is Standard223Receiver, TokenHolder {
   	return (clnAddress == _token || currencyMap[_token].totalSupply > 0);
   }
 
-  /// @dev helper function to get the data of the currency
-  /// @param _token address of the token used with transferAndCall
-  /* function getCurrencyData(address _token) public view returns (string) {
-    return currencyMap[_token].data;
-  } */
-
-  /// @dev helper function to get the data of the currency
-  /// @param _token address of the token used with transferAndCall
-  /* function updateCurrencyData(address _token, string _data) public
+  /// @dev helper function to set metadata for the currency
+  /// @param _token address address of the token to update
+  /// @param _metadata string hash of the metadata of the token, this
+  /// hash can be accessed through IPFS
+  function setCurrencyMetadata(address _token, string _metadata) public
                               tokenIssuerOnly(_token, msg.sender)
                               returns (bool) {
-    currencyMap[_token].data = _data;
-    TokenDataChanged(_token, _data);
+    ColuLocalCurrency(_token).setMetadata(_metadata);
     return true;
-  } */
+  }
 
   /// @dev helper function to get the market maker address form token
   /// @param _token address of the token used with transferAndCall.

--- a/contracts/CurrencyFactory.sol
+++ b/contracts/CurrencyFactory.sol
@@ -17,7 +17,6 @@ contract CurrencyFactory is Standard223Receiver, TokenHolder {
     uint256 totalSupply;
     address owner;
     address mmAddress;
-    string data;
   }
 
 
@@ -60,20 +59,20 @@ contract CurrencyFactory is Standard223Receiver, TokenHolder {
   /// @param _symbol string symbol for CC token that is created.
   /// @param _decimals uint8 percison for CC token that is created.
   /// @param _totalSupply uint256 total supply of the CC token that is created.
-  /// @param _data string IPFS hash for the CC token data.
+  /// @param _metadata string IPFS hash for the CC token data.
   function createCurrency(string _name,
                           string _symbol,
                           uint8 _decimals,
                           uint256 _totalSupply,
-                          string _data) public
+                          string _metadata) public
                           returns (address) {
 
-  	ColuLocalCurrency subToken = new ColuLocalCurrency(_name, _symbol, _decimals, _totalSupply);
+  	ColuLocalCurrency subToken = new ColuLocalCurrency(_name, _symbol, _decimals, _totalSupply, _metadata);
   	EllipseMarketMaker newMarketMaker = new EllipseMarketMaker(mmLibAddress, clnAddress, subToken);
   	//set allowance
   	require(subToken.transfer(newMarketMaker, _totalSupply));
   	require(IEllipseMarketMaker(newMarketMaker).initializeAfterTransfer());
-  	currencyMap[subToken] = CurrencyStruct({ name: _name, decimals: _decimals, totalSupply: _totalSupply, mmAddress: newMarketMaker, data: _data, owner: msg.sender});
+  	currencyMap[subToken] = CurrencyStruct({ name: _name, decimals: _decimals, totalSupply: _totalSupply, mmAddress: newMarketMaker, owner: msg.sender});
     tokens.push(subToken);
   	TokenCreated(subToken, msg.sender);
   	return subToken;
@@ -157,19 +156,19 @@ contract CurrencyFactory is Standard223Receiver, TokenHolder {
 
   /// @dev helper function to get the data of the currency
   /// @param _token address of the token used with transferAndCall
-  function getCurrencyData(address _token) public view returns (string) {
+  /* function getCurrencyData(address _token) public view returns (string) {
     return currencyMap[_token].data;
-  }
+  } */
 
   /// @dev helper function to get the data of the currency
   /// @param _token address of the token used with transferAndCall
-  function updateCurrencyData(address _token, string _data) public
+  /* function updateCurrencyData(address _token, string _data) public
                               tokenIssuerOnly(_token, msg.sender)
                               returns (bool) {
     currencyMap[_token].data = _data;
     TokenDataChanged(_token, _data);
     return true;
-  }
+  } */
 
   /// @dev helper function to get the market maker address form token
   /// @param _token address of the token used with transferAndCall.

--- a/contracts/CurrencyFactory.sol
+++ b/contracts/CurrencyFactory.sol
@@ -91,6 +91,19 @@ contract CurrencyFactory is Standard223Receiver, TokenHolder {
   	return subToken;
   }
 
+  /// @dev create the MarketMaker and the CC token put all the CC token in the Market Maker reserve
+  /// @param _name string name for CC token that is created.
+  /// @param _symbol string symbol for CC token that is created.
+  /// @param _decimals uint8 percison for CC token that is created.
+  /// @param _totalSupply uint256 total supply of the CC token that is created.
+  function createCurrency(string _name,
+                          string _symbol,
+                          uint8 _decimals,
+                          uint256 _totalSupply) public
+                          returns (address) {
+    return createCurrency(_name, _symbol, _decimals, _totalSupply, '');
+  }
+
   /// @dev normal send cln to the market maker contract, sender must approve() before calling method. can only be called by owner
   /// @dev sending CLN will return CC from the reserve to the sender.
   /// @param _token address address of the cc token managed by this factory.

--- a/contracts/IssuanceFactory.sol
+++ b/contracts/IssuanceFactory.sol
@@ -107,6 +107,27 @@ contract IssuanceFactory is CurrencyFactory {
     return tokenAddress;
   }
 
+	/// @dev createIssuance create local currency issuance sale
+	/// @param _startTime uint256 blocktime for sale start
+	/// @param _durationTime uint 256 duration of the sale
+	/// @param _hardcap uint CLN hardcap for issuance
+	/// @param _reserveAmount uint CLN reserve amount
+	/// @param _name string name of the token
+	/// @param _symbol string symbol of the token
+	/// @param _decimals uint8 ERC20 decimals of local currency
+	/// @param _totalSupply uint total supply of the local currency
+	function createIssuance( uint256 _startTime,
+														uint256 _durationTime,
+														uint256 _hardcap,
+														uint256 _reserveAmount,
+														string _name,
+														string _symbol,
+														uint8 _decimals,
+														uint256 _totalSupply) public
+														returns (address) {
+		return createIssuance(_startTime, _durationTime, _hardcap, _reserveAmount, _name, _symbol, _decimals, _totalSupply, '');
+	}
+
   /// @dev internal helper to add currency data to the issuance map
   /// @param _token address token address for this issuance (same as CC adress)
   /// @param _startTime uint256 blocktime for sale start

--- a/contracts/IssuanceFactory.sol
+++ b/contracts/IssuanceFactory.sol
@@ -88,7 +88,7 @@ contract IssuanceFactory is CurrencyFactory {
 	/// @param _symbol string symbol of the token
 	/// @param _decimals uint8 ERC20 decimals of local currency
 	/// @param _totalSupply uint total supply of the local currency
-	/// @param _data string IPFS hash for the CC token data.
+	/// @param _metadata string IPFS hash for the CC token data.
   function createIssuance( uint256 _startTime,
                             uint256 _durationTime,
                             uint256 _hardcap,
@@ -97,7 +97,7 @@ contract IssuanceFactory is CurrencyFactory {
                             string _symbol,
                             uint8 _decimals,
                             uint256 _totalSupply,
-														string _data) public
+														string _metadata) public
                             returns (address) {
     require(_startTime > now);
     require(_durationTime > 0);
@@ -106,7 +106,7 @@ contract IssuanceFactory is CurrencyFactory {
     uint256 R2 = IEllipseMarketMaker(mmLibAddress).calcReserve(_reserveAmount, CLNTotalSupply, _totalSupply);
     uint256 targetPrice = IEllipseMarketMaker(mmLibAddress).getPrice(_reserveAmount, R2, CLNTotalSupply, _totalSupply);
     require(isValidIssuance(_hardcap, targetPrice, _totalSupply, R2));
-    address tokenAddress = super.createCurrency(_name, _symbol, _decimals, _totalSupply, _data);
+    address tokenAddress = super.createCurrency(_name, _symbol, _decimals, _totalSupply, _metadata);
     addToMap(tokenAddress, _startTime, _durationTime, _hardcap, _reserveAmount, targetPrice);
 
     return tokenAddress;

--- a/contracts/IssuanceFactory.sol
+++ b/contracts/IssuanceFactory.sol
@@ -88,6 +88,7 @@ contract IssuanceFactory is CurrencyFactory {
 	/// @param _symbol string symbol of the token
 	/// @param _decimals uint8 ERC20 decimals of local currency
 	/// @param _totalSupply uint total supply of the local currency
+	/// @param _data string IPFS hash for the CC token data.
   function createIssuance( uint256 _startTime,
                             uint256 _durationTime,
                             uint256 _hardcap,
@@ -95,17 +96,18 @@ contract IssuanceFactory is CurrencyFactory {
                             string _name,
                             string _symbol,
                             uint8 _decimals,
-                            uint256 _totalSupply) public
+                            uint256 _totalSupply,
+														string _data) public
                             returns (address) {
     require(_startTime > now);
     require(_durationTime > 0);
-	require(_hardcap > 0);
+		require(_hardcap > 0);
 
     uint256 R2 = IEllipseMarketMaker(mmLibAddress).calcReserve(_reserveAmount, CLNTotalSupply, _totalSupply);
     uint256 targetPrice = IEllipseMarketMaker(mmLibAddress).getPrice(_reserveAmount, R2, CLNTotalSupply, _totalSupply);
     require(isValidIssuance(_hardcap, targetPrice, _totalSupply, R2));
-    address tokenAddress = super.createCurrency(_name,  _symbol,  _decimals,  _totalSupply);
-    addToMap(tokenAddress, _startTime, _startTime + _durationTime, _hardcap, _reserveAmount, targetPrice);
+    address tokenAddress = super.createCurrency(_name, _symbol, _decimals, _totalSupply, _data);
+    addToMap(tokenAddress, _startTime, _durationTime, _hardcap, _reserveAmount, targetPrice);
 
     return tokenAddress;
   }
@@ -113,20 +115,20 @@ contract IssuanceFactory is CurrencyFactory {
   /// @dev internal helper to add currency data to the issuance map
   /// @param _token address token address for this issuance (same as CC adress)
   /// @param _startTime uint256 blocktime for sale start
-  /// @param _endTime uint256 blocktime for sale end
+  /// @param _durationTime uint256 seconds for sale's durationTime
   /// @param _hardcap uint256 sale hardcap
   /// @param _reserveAmount uint256 sale softcap
   /// @param _targetPrice uint256 sale CC price per CLN if it were to pass the softcap
   function addToMap(address _token,
                     uint256 _startTime,
-                    uint256 _endTime,
+                    uint256 _durationTime,
                     uint256 _hardcap,
                     uint256 _reserveAmount,
                     uint256 _targetPrice) private {
   	issueMap[_token] = IssuanceStruct({ hardcap: _hardcap,
 										reserve: _reserveAmount,
 										startTime: _startTime,
-										endTime: _endTime,
+										endTime: _startTime + _durationTime,
 										clnRaised: 0,
 										targetPrice: _targetPrice});
   }

--- a/contracts/IssuanceFactory.sol
+++ b/contracts/IssuanceFactory.sol
@@ -66,11 +66,6 @@ contract IssuanceFactory is CurrencyFactory {
   	_;
   }
 
-  // checks if the instance of market maker contract is closed for public
-  modifier marketClosed(address _token) {
-  	require(!MarketMaker(currencyMap[_token].mmAddress).isOpenForPublic());
-  	_;
-  }
   /// @dev constructor
   /// @param _mmLib address for the deployed elipse market maker contract
   /// @param _clnAddress address for the deployed CLN ERC20 token
@@ -88,7 +83,7 @@ contract IssuanceFactory is CurrencyFactory {
 	/// @param _symbol string symbol of the token
 	/// @param _decimals uint8 ERC20 decimals of local currency
 	/// @param _totalSupply uint total supply of the local currency
-	/// @param _metadata string IPFS hash for the CC token data.
+	/// @param _tokenURI string IPFS hash for the CC token data.
   function createIssuance( uint256 _startTime,
                             uint256 _durationTime,
                             uint256 _hardcap,
@@ -97,7 +92,7 @@ contract IssuanceFactory is CurrencyFactory {
                             string _symbol,
                             uint8 _decimals,
                             uint256 _totalSupply,
-														string _metadata) public
+														string _tokenURI) public
                             returns (address) {
     require(_startTime > now);
     require(_durationTime > 0);
@@ -106,7 +101,7 @@ contract IssuanceFactory is CurrencyFactory {
     uint256 R2 = IEllipseMarketMaker(mmLibAddress).calcReserve(_reserveAmount, CLNTotalSupply, _totalSupply);
     uint256 targetPrice = IEllipseMarketMaker(mmLibAddress).getPrice(_reserveAmount, R2, CLNTotalSupply, _totalSupply);
     require(isValidIssuance(_hardcap, targetPrice, _totalSupply, R2));
-    address tokenAddress = super.createCurrency(_name, _symbol, _decimals, _totalSupply, _metadata);
+    address tokenAddress = super.createCurrency(_name, _symbol, _decimals, _totalSupply, _tokenURI);
     addToMap(tokenAddress, _startTime, _durationTime, _hardcap, _reserveAmount, targetPrice);
 
     return tokenAddress;
@@ -205,9 +200,13 @@ contract IssuanceFactory is CurrencyFactory {
 
     require(ERC20(_token).transfer(msg.sender, ccAmount));
     require(ERC20(clnAddress).transfer(msg.sender, clnAmount));
+
+		Ownable(marketMakerAddress).requestOwnershipTransfer(msg.sender);
+		Ownable(_token).requestOwnershipTransfer(msg.sender);
+
     SaleFinalized(_token, issueMap[_token].clnRaised);
     return true;
-}
+	}
 
   /// @dev Give back CC and get a refund back in CLN,
   /// dev can only be called after sale ended and the softcap not reached

--- a/contracts/IssuanceFactory.sol
+++ b/contracts/IssuanceFactory.sol
@@ -83,7 +83,7 @@ contract IssuanceFactory is CurrencyFactory {
 	/// @param _symbol string symbol of the token
 	/// @param _decimals uint8 ERC20 decimals of local currency
 	/// @param _totalSupply uint total supply of the local currency
-	/// @param _tokenURI string IPFS hash for the CC token data.
+	/// @param _tokenURI string the URI may point to a JSON file that conforms to the "Metadata JSON Schema".
   function createIssuance( uint256 _startTime,
                             uint256 _durationTime,
                             uint256 _hardcap,

--- a/contracts/Ownable.sol
+++ b/contracts/Ownable.sol
@@ -9,8 +9,8 @@ contract Ownable {
     address public owner;
     address public newOwnerCandidate;
 
-    event OwnershipRequested(address indexed _by, address indexed _to);
-    event OwnershipTransferred(address indexed _from, address indexed _to);
+    event OwnershipRequested(address indexed by, address indexed to);
+    event OwnershipTransferred(address indexed from, address indexed to);
 
     /// @dev Constructor sets the original `owner` of the contract to the sender account.
     function Ownable() public {

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,9 +1,5 @@
-var SafeMath = artifacts.require("./SafeMath.sol");
-var Ownable = artifacts.require("./Ownable.sol");
-var BasicToken = artifacts.require("./BasicToken.sol");
+const CurrencyFactory = artifacts.require("./CurrencyFactory.sol")
 
 module.exports = function(deployer) {
-  deployer.deploy(SafeMath);
-  deployer.deploy(Ownable);
+   deployer.deploy(CurrencyFactory, "0x30724fa809d40330eacab9c7ebcfb2a0058c381c", "0x41C9d91E96b933b74ae21bCBb617369CBE022530");
 };
-

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "ethereumjs-abi": "^0.6.4",
     "ganache-cli": "^7.0.0-beta.0",
     "solc": "0.4.18",
-    "truffle": "git+https://github.com/colucom/truffle.git#42072804ab4e535196489b8047a3fce1b6eeebe8",
+    "truffle": "git+https://github.com/colucom/truffle.git",
     "web3": "^1.0.0-beta.22",
     "yargs": "^9.0.1",
     "zeppelin-solidity": "^1.5.0"

--- a/scripts/deployment/abi/getColuLocalCurrencyAbi.js
+++ b/scripts/deployment/abi/getColuLocalCurrencyAbi.js
@@ -1,0 +1,34 @@
+var config = require(__dirname + '/../config')
+var solc = require('solc')
+var fs = require('fs')
+
+var now = +new Date()
+var compilerVersion = config.get('compilerVersion')
+
+var input = {
+  'Ownable.sol': fs.readFileSync(__dirname + '/../../../contracts/Ownable.sol', 'utf8'),
+  'SafeMath.sol': fs.readFileSync(__dirname + '/../../../contracts/SafeMath.sol', 'utf8'),
+  'ERC20.sol': fs.readFileSync(__dirname + '/../../../contracts/ERC20.sol', 'utf8'),
+  'ERC677.sol': fs.readFileSync(__dirname + '/../../../contracts/ERC677.sol', 'utf8'),
+  'ERC223Receiver.sol': fs.readFileSync(__dirname + '/../../../contracts/ERC223Receiver.sol', 'utf8'),
+  'BasicToken.sol': fs.readFileSync(__dirname + '/../../../contracts/BasicToken.sol', 'utf8'),
+  'Standard677Token.sol': fs.readFileSync(__dirname + '/../../../contracts/Standard677Token.sol', 'utf8'),
+  'TokenHolder.sol': fs.readFileSync(__dirname + '/../../../contracts/TokenHolder.sol', 'utf8'),
+  'Standard223Receiver.sol': fs.readFileSync(__dirname + '/../../../contracts/Standard223Receiver.sol', 'utf8'),
+  'TokenOwnable.sol': fs.readFileSync(__dirname + '/../../../contracts/TokenOwnable.sol', 'utf8'),
+  'ColuLocalCurrency.sol': fs.readFileSync(__dirname + '/../../../contracts/ColuLocalCurrency.sol', 'utf8')
+}
+
+solc.loadRemoteVersion(compilerVersion, function(err, solcSnapshot) {
+  if (err) return console.error('err =', err)
+  var contractCompiled = solcSnapshot.compile({sources: input}, 1)
+  var contractObj = contractCompiled.contracts['ColuLocalCurrency.sol:ColuLocalCurrency']
+  var abi = contractObj.interface
+
+  var filePath = __dirname + '/../output/ColuLocalCurrencyABI_' + compilerVersion + '_' + now + '.json'
+
+  fs.writeFile(filePath, abi, {flag: 'w'}, function(err) {
+    if(err) return console.error('err =', err)
+    console.log('abi created at path =', filePath)
+  })
+})

--- a/test/ColuLocalCurrency.js
+++ b/test/ColuLocalCurrency.js
@@ -63,8 +63,8 @@ contract('ColuLocalCurrency', (accounts) => {
         assert.equal(result.logs[0].args.metadata, 'newmetadatahash')
       })
 
-      it('owner should be able to update metadata', async () => {
-        await expectRevert(cc.setMetadata('newmetadata', {from: notOwner}))
+      it('not owner should not be able to update metadata', async () => {
+        await expectRevert(cc.setMetadata('newmetadatahash', {from: notOwner}))
       })
     })
   })

--- a/test/ColuLocalCurrency.js
+++ b/test/ColuLocalCurrency.js
@@ -1,0 +1,71 @@
+const assert = require('chai').assert
+
+const expectRevert = require('./helpers/expectRevert')
+
+const ColuLocalCurrency = artifacts.require('ColuLocalCurrency')
+
+const TOKEN_DECIMALS = 10 ** 18
+
+const MAX_TOKENS = 15 * 10 ** 8 * TOKEN_DECIMALS
+
+contract('ColuLocalCurrency', (accounts) => {
+  let cc
+
+  let owner = accounts[0]
+  let notOwner = accounts[1]
+
+  describe('construction', () => {
+    it('should not construct without a name', async () => {
+      await expectRevert(ColuLocalCurrency.new('', 'MC', 18, MAX_TOKENS, 'metadatahash', {from: owner}))
+    })
+
+    it('should not construct without a symbol', async () => {
+      await expectRevert(ColuLocalCurrency.new('MasterCoin', '', 18, MAX_TOKENS, 'metadatahash', {from: owner}))
+    })
+
+    it('should not construct without a totalSupply', async () => {
+      await expectRevert(ColuLocalCurrency.new('MasterCoin', 'MC', 18, 0, 'metadatahash', {from: owner}))
+    })
+
+    it('should be able to construct currency with all args', async () => {
+      const cc = await ColuLocalCurrency.new('MasterCoin', 'MC', 18, MAX_TOKENS, 'metadatahash', {from: owner})
+      assert.equal((await cc.name()), 'MasterCoin')
+      assert.equal((await cc.symbol()), 'MC')
+      assert.equal((await cc.decimals()), 18)
+      assert.equal((await cc.totalSupply()), MAX_TOKENS)
+      assert.equal((await cc.metadata()), 'metadatahash')
+      assert.equal((await cc.owner()), owner)
+    })
+
+    it('should be able to construct currency without decimals', async () => {
+      const cc = await ColuLocalCurrency.new('MasterCoin', 'MC', 0, MAX_TOKENS, 'metadatahash', {from: owner})
+      assert.equal((await cc.decimals()), 0)
+    })
+
+    it('should be able to construct currency without metadata', async () => {
+      const cc = await ColuLocalCurrency.new('MasterCoin', 'MC', 18, MAX_TOKENS, '', {from: owner})
+      assert.equal((await cc.metadata()), '')
+    })
+  })
+
+  describe('actions', () => {
+    beforeEach(async () => {
+      cc = await ColuLocalCurrency.new('MasterCoin', 'MC', 0, MAX_TOKENS, 'metadatahash', {from: owner})
+    })
+
+    describe('metadata', () => {
+      it('owner should be able to update metadata', async () => {
+        let result = await cc.setMetadata('newmetadatahash', {from: owner})
+        assert.equal((await cc.metadata()), 'newmetadatahash')
+
+        assert.equal(result.logs.length, 1)
+        assert.equal(result.logs[0].event, 'MetadataChanged')
+        assert.equal(result.logs[0].args.metadata, 'newmetadatahash')
+      })
+
+      it('owner should be able to update metadata', async () => {
+        await expectRevert(cc.setMetadata('newmetadata', {from: notOwner}))
+      })
+    })
+  })
+})

--- a/test/ColuLocalCurrency.js
+++ b/test/ColuLocalCurrency.js
@@ -60,7 +60,7 @@ contract('ColuLocalCurrency', (accounts) => {
 
         assert.equal(result.logs.length, 1)
         assert.equal(result.logs[0].event, 'TokenURIChanged')
-        assert.equal(result.logs[0].args.tokenURI, 'ipfs://newhash')
+        assert.equal(result.logs[0].args.newTokenURI, 'ipfs://newhash')
       })
 
       it('not owner should not be able to update metadata', async () => {

--- a/test/ColuLocalCurrency.js
+++ b/test/ColuLocalCurrency.js
@@ -16,55 +16,55 @@ contract('ColuLocalCurrency', (accounts) => {
 
   describe('construction', () => {
     it('should not construct without a name', async () => {
-      await expectRevert(ColuLocalCurrency.new('', 'MC', 18, MAX_TOKENS, 'metadatahash', {from: owner}))
+      await expectRevert(ColuLocalCurrency.new('', 'MC', 18, MAX_TOKENS, 'ipfs://hash', {from: owner}))
     })
 
     it('should not construct without a symbol', async () => {
-      await expectRevert(ColuLocalCurrency.new('MasterCoin', '', 18, MAX_TOKENS, 'metadatahash', {from: owner}))
+      await expectRevert(ColuLocalCurrency.new('MasterCoin', '', 18, MAX_TOKENS, 'ipfs://hash', {from: owner}))
     })
 
     it('should not construct without a totalSupply', async () => {
-      await expectRevert(ColuLocalCurrency.new('MasterCoin', 'MC', 18, 0, 'metadatahash', {from: owner}))
+      await expectRevert(ColuLocalCurrency.new('MasterCoin', 'MC', 18, 0, 'ipfs://hash', {from: owner}))
     })
 
     it('should be able to construct currency with all args', async () => {
-      const cc = await ColuLocalCurrency.new('MasterCoin', 'MC', 18, MAX_TOKENS, 'metadatahash', {from: owner})
+      const cc = await ColuLocalCurrency.new('MasterCoin', 'MC', 18, MAX_TOKENS, 'ipfs://hash', {from: owner})
       assert.equal((await cc.name()), 'MasterCoin')
       assert.equal((await cc.symbol()), 'MC')
       assert.equal((await cc.decimals()), 18)
       assert.equal((await cc.totalSupply()), MAX_TOKENS)
-      assert.equal((await cc.metadata()), 'metadatahash')
+      assert.equal((await cc.tokenURI()), 'ipfs://hash')
       assert.equal((await cc.owner()), owner)
     })
 
     it('should be able to construct currency without decimals', async () => {
-      const cc = await ColuLocalCurrency.new('MasterCoin', 'MC', 0, MAX_TOKENS, 'metadatahash', {from: owner})
+      const cc = await ColuLocalCurrency.new('MasterCoin', 'MC', 0, MAX_TOKENS, 'ipfs://hash', {from: owner})
       assert.equal((await cc.decimals()), 0)
     })
 
     it('should be able to construct currency without metadata', async () => {
       const cc = await ColuLocalCurrency.new('MasterCoin', 'MC', 18, MAX_TOKENS, '', {from: owner})
-      assert.equal((await cc.metadata()), '')
+      assert.equal((await cc.tokenURI()), '')
     })
   })
 
   describe('actions', () => {
     beforeEach(async () => {
-      cc = await ColuLocalCurrency.new('MasterCoin', 'MC', 0, MAX_TOKENS, 'metadatahash', {from: owner})
+      cc = await ColuLocalCurrency.new('MasterCoin', 'MC', 0, MAX_TOKENS, 'ipfs://hash', {from: owner})
     })
 
     describe('metadata', () => {
       it('owner should be able to update metadata', async () => {
-        let result = await cc.setMetadata('newmetadatahash', {from: owner})
-        assert.equal((await cc.metadata()), 'newmetadatahash')
+        let result = await cc.setTokenURI('ipfs://newhash', {from: owner})
+        assert.equal((await cc.tokenURI()), 'ipfs://newhash')
 
         assert.equal(result.logs.length, 1)
-        assert.equal(result.logs[0].event, 'MetadataChanged')
-        assert.equal(result.logs[0].args.metadata, 'newmetadatahash')
+        assert.equal(result.logs[0].event, 'TokenURIChanged')
+        assert.equal(result.logs[0].args.tokenURI, 'ipfs://newhash')
       })
 
       it('not owner should not be able to update metadata', async () => {
-        await expectRevert(cc.setMetadata('newmetadatahash', {from: notOwner}))
+        await expectRevert(cc.setTokenURI('ipfs://newhash', {from: notOwner}))
       })
     })
   })

--- a/test/CurrencyFactory.js
+++ b/test/CurrencyFactory.js
@@ -86,7 +86,7 @@ contract('CurrencyFactory', (accounts) => {
         await cln.transfer(notOwner, THOUSAND_CLN * 1000);
     });
 
-    describe.only('Construction.', async () => {
+    describe('Construction.', async () => {
 
         it('should not construct without market making lib address', async () => {
             await expectRevert(CurrencyFactory.new(null, cln.address,  {from: owner} ));

--- a/test/CurrencyFactory.js
+++ b/test/CurrencyFactory.js
@@ -106,7 +106,7 @@ contract('CurrencyFactory', (accounts) => {
          });
     });
 
-    describe.only('Creating Local Currency and its MarketMaker.', async () => {
+    describe('Creating Local Currency and its MarketMaker.', async () => {
         beforeEach(async () => {
             await cln.makeTokensTransferable();
             factory = await CurrencyFactory.new(mmLib.address, cln.address,  {from: factoryOwner} )
@@ -174,7 +174,7 @@ contract('CurrencyFactory', (accounts) => {
         beforeEach(async () => {
             factory = await CurrencyFactory.new(mmLib.address, cln.address,  {from: factoryOwner} )
             assert.equal(await factory.clnAddress() ,cln.address);
-            let result = await factory.createCurrency('Some Name', 'SON', 18, CC_MAX_TOKENS, '', {from: owner});
+            let result = await factory.createCurrency('Some Name', 'SON', 18, CC_MAX_TOKENS, 'metadatahash', {from: owner});
             assert.lengthOf(result.logs, 1);
             let event = result.logs[0];
             assert.equal(event.event, 'TokenCreated');
@@ -372,6 +372,18 @@ contract('CurrencyFactory', (accounts) => {
             it('should not support other contracts', async () => {
                 assert.isNotOk(await factory.supportsToken(mmLib.address));
             });
+
+            describe('Updating the storage', () => {
+              it('should allow to update storage if owner', async () => {
+                const result = await factory.setCurrencyMetadata(cc.address, 'newmetadatahash', {from: owner})
+                assert(await cc.metadata(), 'newmetadatahash')
+              })
+
+              it('should not allow to update storage if not owner', async () => {
+                await expectRevert(factory.setCurrencyMetadata(cc.address, 'newmetadatahash', {from: notOwner}))
+                assert(await cc.metadata(), 'metadatahash')
+              })
+            })
         });
     });
 

--- a/test/CurrencyFactory.js
+++ b/test/CurrencyFactory.js
@@ -373,15 +373,15 @@ contract('CurrencyFactory', (accounts) => {
                 assert.isNotOk(await factory.supportsToken(mmLib.address));
             });
 
-            describe('Updating the storage', () => {
+            describe('Storage functionality.', () => {
               it('should allow to update storage if owner', async () => {
                 const result = await factory.setCurrencyMetadata(cc.address, 'newmetadatahash', {from: owner})
-                assert(await cc.metadata(), 'newmetadatahash')
+                assert.equal(await cc.metadata(), 'newmetadatahash')
               })
 
               it('should not allow to update storage if not owner', async () => {
                 await expectRevert(factory.setCurrencyMetadata(cc.address, 'newmetadatahash', {from: notOwner}))
-                assert(await cc.metadata(), 'metadatahash')
+                assert.equal(await cc.metadata(), 'metadatahash')
               })
             })
         });

--- a/test/CurrencyFactory.js
+++ b/test/CurrencyFactory.js
@@ -53,7 +53,7 @@ const encodeExtractData = () => {
 };
 
 const createAndValidateCurrency = async (factory, name, symbol, ownerAddress) => {
-  let result = await factory.createCurrency('Some Name', 'SON', 18, CC_MAX_TOKENS, {from: ownerAddress});
+  let result = await factory.createCurrency('Some Name', 'SON', 18, CC_MAX_TOKENS, '', {from: ownerAddress});
   assert.lengthOf(result.logs, 1);
   let event = result.logs[0];
   assert.equal(event.event, 'TokenCreated');
@@ -86,7 +86,7 @@ contract('CurrencyFactory', (accounts) => {
         await cln.transfer(notOwner, THOUSAND_CLN * 1000);
     });
 
-    describe('Construction.', async () => {
+    describe.only('Construction.', async () => {
 
         it('should not construct without market making lib address', async () => {
             await expectRevert(CurrencyFactory.new(null, cln.address,  {from: owner} ));
@@ -104,26 +104,26 @@ contract('CurrencyFactory', (accounts) => {
          });
     });
 
-    describe('Creating Local Currency and its MarketMaker.', async () => {
+    describe.only('Creating Local Currency and its MarketMaker.', async () => {
         beforeEach(async () => {
             await cln.makeTokensTransferable();
             factory = await CurrencyFactory.new(mmLib.address, cln.address,  {from: factoryOwner} )
         });
 
         it('should not be able to create without name', async () => {
-            await expectRevert(factory.createCurrency('', 'SON', 18, CC_MAX_TOKENS, {from: owner}));
+            await expectRevert(factory.createCurrency('', 'SON', 18, CC_MAX_TOKENS, '', {from: owner}));
         });
 
         it('should not be able to create without symbol', async () => {
-            await expectRevert(factory.createCurrency('Some Name', '', 18, CC_MAX_TOKENS, {from: owner}));
+            await expectRevert(factory.createCurrency('Some Name', '', 18, CC_MAX_TOKENS, '', {from: owner}));
         });
 
         it('should not be able to create with zero supply', async () => {
-            await expectRevert(factory.createCurrency('Some Name', 'SON', 18, 0, {from: owner}));
+            await expectRevert(factory.createCurrency('Some Name', 'SON', 18, 0, '',{from: owner}));
         });
 
         it('should be able to create with correct parameters', async () => {
-            let result = await factory.createCurrency('Some Name', 'SON', 18, CC_MAX_TOKENS, {from: owner});
+            let result = await factory.createCurrency('Some Name', 'SON', 18, CC_MAX_TOKENS, '', {from: owner});
             // assert.equal(result.owner, owner);
             assert.lengthOf(result.logs, 1);
             let event = result.logs[0];
@@ -136,23 +136,23 @@ contract('CurrencyFactory', (accounts) => {
         });
 
         it('should allow to create two tokens with same name', async () => {
-            assert(await factory.createCurrency('Some Name', 'SON1', 18, CC_MAX_TOKENS, {from: owner}));
-            assert(await factory.createCurrency('Some Name', 'SON2', 18, CC_MAX_TOKENS, {from: owner}));
+            assert(await factory.createCurrency('Some Name', 'SON1', 18, CC_MAX_TOKENS, '', {from: owner}));
+            assert(await factory.createCurrency('Some Name', 'SON2', 18, CC_MAX_TOKENS, '', {from: owner}));
         });
 
         it('should allow to create two tokens with same symbol', async () => {
-            assert(await factory.createCurrency('Some Name1', 'SON', 18, CC_MAX_TOKENS, {from: owner}));
-            assert(await factory.createCurrency('Some Name2', 'SON', 18, CC_MAX_TOKENS, {from: owner}));
+            assert(await factory.createCurrency('Some Name1', 'SON', 18, CC_MAX_TOKENS, '', {from: owner}));
+            assert(await factory.createCurrency('Some Name2', 'SON', 18, CC_MAX_TOKENS, '', {from: owner}));
         });
     });
 
-    describe('Interact with MarketMaker through factory before opening market.', async () => {
+    describe.only('Interact with MarketMaker through factory before opening market.', async () => {
         let cc;
 
         beforeEach(async () => {
             factory = await CurrencyFactory.new(mmLib.address, cln.address,  {from: factoryOwner} )
             assert.equal(await factory.clnAddress() ,cln.address);
-            let result = await factory.createCurrency('Some Name', 'SON', 18, CC_MAX_TOKENS, {from: owner});
+            let result = await factory.createCurrency('Some Name', 'SON', 18, CC_MAX_TOKENS, '', {from: owner});
             assert.lengthOf(result.logs, 1);
             let event = result.logs[0];
             assert.equal(event.event, 'TokenCreated');
@@ -295,7 +295,7 @@ contract('CurrencyFactory', (accounts) => {
 
               // insert 2000 CLN to CC2
               tokenAddress2 = (await factory.createCurrency(
-                'Other Name', 'ON', 18, CC_MAX_TOKENS, {from: owner})).logs[0].args.token;
+                'Other Name', 'ON', 18, CC_MAX_TOKENS, '', {from: owner})).logs[0].args.token;
               const cc2 = await ColuLocalCurrency.at(tokenAddress2);
               insertCLNtoMarketMakerMessage = encodeInsertData(tokenAddress2);
               await cln.transferAndCall(factory.address, 2 * THOUSAND_CLN, insertCLNtoMarketMakerMessage);
@@ -354,7 +354,7 @@ contract('CurrencyFactory', (accounts) => {
     });
 
 
-    describe('Create two different currencies one after another.', async () => {
+    describe.only('Create two different currencies one after another.', async () => {
       let tokenAddress1;
       let tokenAddress2;
 
@@ -363,11 +363,11 @@ contract('CurrencyFactory', (accounts) => {
 
       beforeEach(async () => {
           factory = await CurrencyFactory.new(mmLib.address, cln.address,  {from: factoryOwner} )
-          let result = await factory.createCurrency('Some Name', 'SON', 18, CC_MAX_TOKENS, {from: owner1});
+          let result = await factory.createCurrency('Some Name', 'SON', 18, CC_MAX_TOKENS, '', {from: owner1});
           let event = result.logs[0];
           tokenAddress1 = event.args.token;
 
-          result = await factory.createCurrency('Other Name', 'ON', 18, CC_MAX_TOKENS, {from: owner2});
+          result = await factory.createCurrency('Other Name', 'ON', 18, CC_MAX_TOKENS, '', {from: owner2});
           event = result.logs[0];
           tokenAddress2 = event.args.token;
       });
@@ -416,7 +416,7 @@ contract('CurrencyFactory', (accounts) => {
           assert.equal(cc1Balance.div(TOKEN_DECIMALS).toFixed(0), 17321);
 
           // Create another currency
-          result = await factory.createCurrency('Other Name', 'ON', 18, CC_MAX_TOKENS, {from: owner1});
+          result = await factory.createCurrency('Other Name', 'ON', 18, CC_MAX_TOKENS, '', {from: owner1});
           event = result.logs[0];
           tokenAddress3 = event.args.token;
 

--- a/test/IssuanceFactory.js
+++ b/test/IssuanceFactory.js
@@ -45,6 +45,11 @@ const REFUND_ABI = {
     ]
 }
 
+const CREATE_ISSUANCE_SIGS = {
+    full: 'uint256,uint256,uint256,uint256,string,string,uint8,uint256,string',
+    withoutMetadata: 'uint256,uint256,uint256,uint256,string,string,uint8,uint256'
+};
+
 const encodeParticipateMessage = (token) => {
     abi = PARTICIPATE_ABI;
     params = [token];
@@ -107,36 +112,36 @@ contract('IssuanceFactory', (accounts) => {
         });
 
         it('should not be able to create without name', async () => {
-            await expectRevert(factory.createIssuance(Date.now() + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2,'', 'SON', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner}));
+            await expectRevert(factory.createIssuance[CREATE_ISSUANCE_SIGS.full](Date.now() + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2,'', 'SON', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner}));
         });
 
         it('should not be able to create without symbol', async () => {
-            await expectRevert(factory.createIssuance(Date.now() + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2, 'Some Name', '', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner}));
+            await expectRevert(factory.createIssuance[CREATE_ISSUANCE_SIGS.full](Date.now() + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2, 'Some Name', '', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner}));
         });
 
         it('should not be able to create with zero supply', async () => {
-            await expectRevert(factory.createIssuance(Date.now() + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2, 'Some Name', 'SON', 18, 0, 'ipfs://hash', {from: owner}));
+            await expectRevert(factory.createIssuance[CREATE_ISSUANCE_SIGS.full](Date.now() + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2, 'Some Name', 'SON', 18, 0, 'ipfs://hash', {from: owner}));
         });
 
         it('should not be able to create with too small reserve', async () => {
-            await expectRevert(factory.createIssuance(Date.now() + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 1000, 'Some Name', 'SON', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner}));
+            await expectRevert(factory.createIssuance[CREATE_ISSUANCE_SIGS.full](Date.now() + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 1000, 'Some Name', 'SON', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner}));
         });
 
         it('should not be able to create with start time in past', async () => {
-            await expectRevert(factory.createIssuance(Date.now() - SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 1000, 'Some Name', 'SON', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner}));
+            await expectRevert(factory.createIssuance[CREATE_ISSUANCE_SIGS.full](Date.now() - SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 1000, 'Some Name', 'SON', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner}));
         });
 
         it('should not be able to create with hardcap zero', async () => {
-            await expectRevert(factory.createIssuance(Date.now() - SALE_TIME_TILL_START, SALE_DURATION_TIME, 0, THOUSAND_CLN / 1000, 'Some Name', 'SON', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner}));
+            await expectRevert(factory.createIssuance[CREATE_ISSUANCE_SIGS.full](Date.now() - SALE_TIME_TILL_START, SALE_DURATION_TIME, 0, THOUSAND_CLN / 1000, 'Some Name', 'SON', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner}));
         });
 
         it('should not be able to create with duration zero', async () => {
-            await expectRevert(factory.createIssuance(Date.now() + SALE_TIME_TILL_START, 0, THOUSAND_CLN, THOUSAND_CLN / 1000, 'Some Name', 'SON', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner}));
+            await expectRevert(factory.createIssuance[CREATE_ISSUANCE_SIGS.full](Date.now() + SALE_TIME_TILL_START, 0, THOUSAND_CLN, THOUSAND_CLN / 1000, 'Some Name', 'SON', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner}));
         });
 
         it('should be able to create with correct parameters', async () => {
             now = await (web3.eth.getBlock(web3.eth.blockNumber)).timestamp;
-            let result = await factory.createIssuance(now + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2, 'Some Name', 'SON', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner});
+            let result = await factory.createIssuance[CREATE_ISSUANCE_SIGS.full](now + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2, 'Some Name', 'SON', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner});
             assert.lengthOf(result.logs, 1);
             let event = result.logs[0];
             assert.equal(event.event, 'TokenCreated');
@@ -168,9 +173,43 @@ contract('IssuanceFactory', (accounts) => {
             assert.equal((await cc.owner()), factory.address)
         });
 
-        it('should be able to create without tokenURI', async () => {
+        it('should be able to create with correct parameters (without metadata)', async () => {
+            now = await (web3.eth.getBlock(web3.eth.blockNumber)).timestamp;
+            let result = await factory.createIssuance[CREATE_ISSUANCE_SIGS.withoutMetadata](now + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2, 'Some Name', 'SON', 18, CC_MAX_TOKENS, {from: owner});
+            assert.lengthOf(result.logs, 1);
+            let event = result.logs[0];
+            assert.equal(event.event, 'TokenCreated');
+            const tokenAddress = event.args.token
+            assert(expect(tokenAddress).to.be.a('String'));
+
+            // Validating Issuance Struct initialization
+            const issuanceStruct = await factory.issueMap(tokenAddress);
+            // hardcap
+            assert(issuanceStruct[0].eq(THOUSAND_CLN))
+            // reserve
+            assert(issuanceStruct[1].eq(THOUSAND_CLN / 2))
+            // start time
+            assert(issuanceStruct[2].eq(now + SALE_TIME_TILL_START))
+            // end time
+            assert(issuanceStruct[3].eq(now + SALE_TIME_TILL_START + SALE_DURATION_TIME))
+            // target price (real target price is price / precision)
+            assert.equal(issuanceStruct[4].toNumber(), 12247445652053500000)
+            // CLN raised
+            assert(issuanceStruct[5].eq(0))
+
+            // validate that the token created correctly
+            cc = await ColuLocalCurrency.at(tokenAddress);
+            assert.equal((await cc.name()), 'Some Name')
+            assert.equal((await cc.symbol()), 'SON')
+            assert.equal((await cc.decimals()), 18)
+            assert.equal((await cc.totalSupply()), CC_MAX_TOKENS)
+            assert.equal((await cc.tokenURI()), '')
+            assert.equal((await cc.owner()), factory.address)
+        });
+
+        it('should be able to create with empty tokenURI', async () => {
           now = await (web3.eth.getBlock(web3.eth.blockNumber)).timestamp;
-          let result = await factory.createIssuance(
+          let result = await factory.createIssuance[CREATE_ISSUANCE_SIGS.full](
             now + SALE_TIME_TILL_START,
             SALE_DURATION_TIME,
             THOUSAND_CLN,
@@ -195,7 +234,7 @@ contract('IssuanceFactory', (accounts) => {
             factory = await IssuanceFactory.new(mmLib.address, cln.address, {from: owner} );
             let clnAddress = await factory.clnAddress();
 
-            tokenAddress = (await factory.createIssuance(
+            tokenAddress = (await factory.createIssuance[CREATE_ISSUANCE_SIGS.full](
                 now + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2,
                 'Some Name', 'SON', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner})).logs[0].args.token;
 
@@ -203,7 +242,7 @@ contract('IssuanceFactory', (accounts) => {
         });
 
         it('should create currency in a correct way', async () => {
-            let result = await factory.createIssuance(now + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2, 'Some Name', 'SON', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner});
+            let result = await factory.createIssuance[CREATE_ISSUANCE_SIGS.full](now + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2, 'Some Name', 'SON', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner});
             assert.lengthOf(result.logs, 1);
             let event = result.logs[0];
             assert.equal(event.event, 'TokenCreated');
@@ -783,7 +822,7 @@ contract('IssuanceFactory', (accounts) => {
             it('perform 2 issuances in parallel', async () => {
                 const ownerInnitialClnBalance = await cln.balanceOf(owner);
                 const owner2 = accounts[3]
-                tokenAddress2 = (await factory.createIssuance(
+                tokenAddress2 = (await factory.createIssuance[CREATE_ISSUANCE_SIGS.full](
                     now + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2,
                     'Some Name2', 'SON2', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner2})).logs[0].args.token;
                 const cc2 = await ColuLocalCurrency.at(tokenAddress2);
@@ -904,7 +943,7 @@ contract('IssuanceFactory', (accounts) => {
             });
 
             it('should return correct number of issuances when running two issuances simultaneously', async () => {
-                await factory.createIssuance(
+                await factory.createIssuance[CREATE_ISSUANCE_SIGS.full](
                     now + 2 * SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2,
                     'Some Name2', 'SON2', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner});
 
@@ -958,7 +997,7 @@ contract('IssuanceFactory', (accounts) => {
 
                 now = await (web3.eth.getBlock(web3.eth.blockNumber)).timestamp;
 
-                await factory.createIssuance(
+                await factory.createIssuance[CREATE_ISSUANCE_SIGS.full](
                     now + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2,
                     'Some Name3', 'SON3', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner});
 
@@ -970,7 +1009,7 @@ contract('IssuanceFactory', (accounts) => {
 
                 now = await (web3.eth.getBlock(web3.eth.blockNumber)).timestamp;
 
-                await factory.createIssuance(
+                await factory.createIssuance[CREATE_ISSUANCE_SIGS.full](
                     now + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2,
                     'Some Name4', 'SON4', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner});
 
@@ -1091,7 +1130,7 @@ contract('IssuanceFactory', (accounts) => {
             });
 
             it('should return correct number of issuances when running two issuances simultaneously', async () => {
-                await factory.createIssuance(
+                await factory.createIssuance[CREATE_ISSUANCE_SIGS.full](
                     now + 2 * SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2,
                     'Some Name2', 'SON2', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner});
 
@@ -1145,7 +1184,7 @@ contract('IssuanceFactory', (accounts) => {
 
                 now = await (web3.eth.getBlock(web3.eth.blockNumber)).timestamp;
 
-                await factory.createIssuance(
+                await factory.createIssuance[CREATE_ISSUANCE_SIGS.full](
                     now + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2,
                     'Some Name3', 'SON3', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner});
 
@@ -1157,7 +1196,7 @@ contract('IssuanceFactory', (accounts) => {
 
                 now = await (web3.eth.getBlock(web3.eth.blockNumber)).timestamp;
 
-                await factory.createIssuance(
+                await factory.createIssuance[CREATE_ISSUANCE_SIGS.full](
                     now + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2,
                     'Some Name4', 'SON4', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner});
 
@@ -1177,7 +1216,7 @@ contract('IssuanceFactory', (accounts) => {
                 beforeEach(async () => {
                     tokenAddressArray = [tokenAddress];
                     for (let i = 0; i < 19; i++) {
-                        const tokenAddressTmp = (await factory.createIssuance(
+                        const tokenAddressTmp = (await factory.createIssuance[CREATE_ISSUANCE_SIGS.full](
                             now + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2,
                             `Some Name ${i}`, `SON${i}`, 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner})).logs[0].args.token;
                         tokenAddressArray.push(tokenAddressTmp)

--- a/test/IssuanceFactory.js
+++ b/test/IssuanceFactory.js
@@ -211,7 +211,7 @@ contract('IssuanceFactory', (accounts) => {
             assert(expect(tokenAddress).to.be.a('String'));
         });
 
-        describe.only('Storage functionality.', () => {
+        describe('Storage functionality.', () => {
           it('should allow to update storage if owner', async () => {
             const result = await factory.setCurrencyMetadata(cc.address, 'newmetadatahash', {from: owner})
             assert.equal(await cc.metadata(), 'newmetadatahash')

--- a/test/IssuanceFactory.js
+++ b/test/IssuanceFactory.js
@@ -107,36 +107,36 @@ contract('IssuanceFactory', (accounts) => {
         });
 
         it('should not be able to create without name', async () => {
-            await expectRevert(factory.createIssuance(Date.now() + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2,'', 'SON', 18, CC_MAX_TOKENS, 'metadatahash', {from: owner}));
+            await expectRevert(factory.createIssuance(Date.now() + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2,'', 'SON', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner}));
         });
 
         it('should not be able to create without symbol', async () => {
-            await expectRevert(factory.createIssuance(Date.now() + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2, 'Some Name', '', 18, CC_MAX_TOKENS, 'metadatahash', {from: owner}));
+            await expectRevert(factory.createIssuance(Date.now() + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2, 'Some Name', '', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner}));
         });
 
         it('should not be able to create with zero supply', async () => {
-            await expectRevert(factory.createIssuance(Date.now() + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2, 'Some Name', 'SON', 18, 0, 'metadatahash', {from: owner}));
+            await expectRevert(factory.createIssuance(Date.now() + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2, 'Some Name', 'SON', 18, 0, 'ipfs://hash', {from: owner}));
         });
 
         it('should not be able to create with too small reserve', async () => {
-            await expectRevert(factory.createIssuance(Date.now() + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 1000, 'Some Name', 'SON', 18, CC_MAX_TOKENS, 'metadatahash', {from: owner}));
+            await expectRevert(factory.createIssuance(Date.now() + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 1000, 'Some Name', 'SON', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner}));
         });
 
         it('should not be able to create with start time in past', async () => {
-            await expectRevert(factory.createIssuance(Date.now() - SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 1000, 'Some Name', 'SON', 18, CC_MAX_TOKENS, 'metadatahash', {from: owner}));
+            await expectRevert(factory.createIssuance(Date.now() - SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 1000, 'Some Name', 'SON', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner}));
         });
 
         it('should not be able to create with hardcap zero', async () => {
-            await expectRevert(factory.createIssuance(Date.now() - SALE_TIME_TILL_START, SALE_DURATION_TIME, 0, THOUSAND_CLN / 1000, 'Some Name', 'SON', 18, CC_MAX_TOKENS, 'metadatahash', {from: owner}));
+            await expectRevert(factory.createIssuance(Date.now() - SALE_TIME_TILL_START, SALE_DURATION_TIME, 0, THOUSAND_CLN / 1000, 'Some Name', 'SON', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner}));
         });
 
         it('should not be able to create with duration zero', async () => {
-            await expectRevert(factory.createIssuance(Date.now() + SALE_TIME_TILL_START, 0, THOUSAND_CLN, THOUSAND_CLN / 1000, 'Some Name', 'SON', 18, CC_MAX_TOKENS, 'metadatahash', {from: owner}));
+            await expectRevert(factory.createIssuance(Date.now() + SALE_TIME_TILL_START, 0, THOUSAND_CLN, THOUSAND_CLN / 1000, 'Some Name', 'SON', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner}));
         });
 
         it('should be able to create with correct parameters', async () => {
             now = await (web3.eth.getBlock(web3.eth.blockNumber)).timestamp;
-            let result = await factory.createIssuance(now + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2, 'Some Name', 'SON', 18, CC_MAX_TOKENS, 'metadatahash', {from: owner});
+            let result = await factory.createIssuance(now + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2, 'Some Name', 'SON', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner});
             assert.lengthOf(result.logs, 1);
             let event = result.logs[0];
             assert.equal(event.event, 'TokenCreated');
@@ -164,11 +164,11 @@ contract('IssuanceFactory', (accounts) => {
             assert.equal((await cc.symbol()), 'SON')
             assert.equal((await cc.decimals()), 18)
             assert.equal((await cc.totalSupply()), CC_MAX_TOKENS)
-            assert.equal((await cc.metadata()), 'metadatahash')
+            assert.equal((await cc.tokenURI()), 'ipfs://hash')
             assert.equal((await cc.owner()), factory.address)
         });
 
-        it('should be able to create without metadaha', async () => {
+        it('should be able to create without tokenURI', async () => {
           now = await (web3.eth.getBlock(web3.eth.blockNumber)).timestamp;
           let result = await factory.createIssuance(
             now + SALE_TIME_TILL_START,
@@ -183,7 +183,7 @@ contract('IssuanceFactory', (accounts) => {
 
           const tokenAddress = result.logs[0].args.token
           cc = await ColuLocalCurrency.at(tokenAddress)
-          assert.equal((await cc.metadata()), '')
+          assert.equal((await cc.tokenURI()), '')
         })
     });
 
@@ -197,13 +197,13 @@ contract('IssuanceFactory', (accounts) => {
 
             tokenAddress = (await factory.createIssuance(
                 now + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2,
-                'Some Name', 'SON', 18, CC_MAX_TOKENS, 'metadatahash', {from: owner})).logs[0].args.token;
+                'Some Name', 'SON', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner})).logs[0].args.token;
 
             cc = await ColuLocalCurrency.at(tokenAddress);
         });
 
         it('should create currency in a correct way', async () => {
-            let result = await factory.createIssuance(now + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2, 'Some Name', 'SON', 18, CC_MAX_TOKENS, 'metadatahash', {from: owner});
+            let result = await factory.createIssuance(now + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2, 'Some Name', 'SON', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner});
             assert.lengthOf(result.logs, 1);
             let event = result.logs[0];
             assert.equal(event.event, 'TokenCreated');
@@ -211,15 +211,49 @@ contract('IssuanceFactory', (accounts) => {
             assert(expect(tokenAddress).to.be.a('String'));
         });
 
-        describe('Storage functionality.', () => {
-          it('should allow to update storage if owner', async () => {
-            const result = await factory.setCurrencyMetadata(cc.address, 'newmetadatahash', {from: owner})
-            assert.equal(await cc.metadata(), 'newmetadatahash')
+        describe('Metadata functionality.', () => {
+          it('should allow to update tokenURI if owner', async () => {
+            const result = await factory.setTokenURI(cc.address, 'ipfs://newhash', {from: owner})
+            assert.equal(await cc.tokenURI(), 'ipfs://newhash')
           })
 
-          it('should not allow to update storage if not owner', async () => {
-            await expectRevert(factory.setCurrencyMetadata(cc.address, 'newmetadatahash', {from: participant}))
-            assert.equal(await cc.metadata(), 'metadatahash')
+          it('should not allow to update tokenURI if not owner', async () => {
+            await expectRevert(factory.setTokenURI(cc.address, 'ipfs://newhash', {from: participant}))
+            assert.equal(await cc.tokenURI(), 'ipfs://hash')
+          })
+
+          it('should not allow to update tokenURI via cc', async () => {
+            await expectRevert(cc.setTokenURI('ipfs://newhash', {from: owner}))
+            assert.equal(await cc.tokenURI(), 'ipfs://hash')
+          })
+
+          context('After the issuance.', () => {
+            beforeEach(async () => {
+              await time.increaseTime(SALE_TIME_TILL_START);
+
+              await cln.approve(factory.address, THOUSAND_CLN, {from: owner});
+              await factory.participate['address,uint256'](tokenAddress, THOUSAND_CLN, {from: owner});
+
+              // reaching end of sale
+              await time.increaseTime(SALE_ENDED_TIME);
+              await factory.finalize(tokenAddress, {from: owner});
+              await cc.acceptOwnership({from: owner})
+            })
+
+            it('should allow to update tokenURI directly if owner', async () => {
+              await cc.setTokenURI('ipfs://newhash', {from: owner})
+              assert.equal(await cc.tokenURI(), 'ipfs://newhash')
+            })
+
+            it('should not allow to update tokenURI if not owner', async () => {
+              await expectRevert(cc.setTokenURI('ipfs://newhash', {from: participant}))
+              assert.equal(await cc.tokenURI(), 'ipfs://hash')
+            })
+
+            it('should not allow to update tokenURI via the issuance', async () => {
+              await expectRevert(factory.setTokenURI(tokenAddress, 'ipfs://newhash', {from: participant}))
+              assert.equal(await cc.tokenURI(), 'ipfs://hash')
+            })
           })
         })
 
@@ -429,28 +463,46 @@ contract('IssuanceFactory', (accounts) => {
                     const clnBalance = await cln.balanceOf(owner);
                     const THOUSAND_CLN_3_4 = THOUSAND_CLN / 4 * 3
                     await cln.approve(factory.address, THOUSAND_CLN_3_4, {from: participant});
-                    const result = await factory.participate['address,uint256'](tokenAddress, THOUSAND_CLN_3_4, {from: participant});
+                    await factory.participate['address,uint256'](tokenAddress, THOUSAND_CLN_3_4, {from: participant});
                     assert((await factory.totalCLNcustodian()).eq(THOUSAND_CLN_3_4));
                     assert.equal((await cc.balanceOf(participant)).div(10 ** 8).toNumber(), 91855842390401.25);
-
 
                     // reaching end of sale
                     await time.increaseTime(SALE_ENDED_TIME);
 
                     // finalizing
-                    const logs = (await factory.finalize(tokenAddress, {from: owner})).logs;
-
-                    assert.lengthOf(logs, 1);
-                    const event = logs[0];
-                    assert.equal(event.event, 'SaleFinalized');
-
-                    assert.equal(tokenAddress, event.args.token);
-                    assert.equal(THOUSAND_CLN_3_4, event.args.clnRaised);
+                    const result = await factory.finalize(tokenAddress, {from: owner});
 
                     // owner of the currency receives CLN raised above the specified reserve amount
                     assert((await factory.totalCLNcustodian()).eq(THOUSAND_CLN / 2));
                     const finalClnBalance = await cln.balanceOf(owner);
                     assert(finalClnBalance.eq(clnBalance.plus(THOUSAND_CLN / 4)));
+
+                    const logs = result.logs
+                    assert.lengthOf(logs, 3);
+
+                    assert.equal(logs[0].event, 'OwnershipRequested');
+                    assert.equal(factory.address, logs[0].args.by);
+                    assert.equal(owner, logs[0].args.to);
+
+                    assert.equal(logs[1].event, 'OwnershipRequested');
+                    assert.equal(factory.address, logs[1].args.by);
+                    assert.equal(owner, logs[1].args.to);
+
+                    assert.equal(logs[2].event, 'SaleFinalized');
+                    assert.equal(tokenAddress, logs[2].args.token);
+                    assert.equal(THOUSAND_CLN_3_4, logs[2].args.clnRaised);
+
+
+                    const marketMakerAddress = await factory.getMarketMakerAddressFromToken(tokenAddress);
+                    const marketMaker = await EllipseMarketMaker.at(marketMakerAddress);
+                    assert.equal(await marketMaker.newOwnerCandidate(), owner);
+                    assert.equal(await cc.newOwnerCandidate(), owner);
+
+                    await marketMaker.acceptOwnership({from: owner})
+                    await cc.acceptOwnership({from: owner})
+                    assert.equal(await marketMaker.owner(), owner);
+                    assert.equal(await cc.owner(), owner);
                 });
 
                 it('should not be able to finalize twice', async () => {
@@ -733,7 +785,7 @@ contract('IssuanceFactory', (accounts) => {
                 const owner2 = accounts[3]
                 tokenAddress2 = (await factory.createIssuance(
                     now + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2,
-                    'Some Name2', 'SON2', 18, CC_MAX_TOKENS, 'metadatahash', {from: owner2})).logs[0].args.token;
+                    'Some Name2', 'SON2', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner2})).logs[0].args.token;
                 const cc2 = await ColuLocalCurrency.at(tokenAddress2);
 
                 const clnBalanceParticipant = await cln.balanceOf(participant)
@@ -854,7 +906,7 @@ contract('IssuanceFactory', (accounts) => {
             it('should return correct number of issuances when running two issuances simultaneously', async () => {
                 await factory.createIssuance(
                     now + 2 * SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2,
-                    'Some Name2', 'SON2', 18, CC_MAX_TOKENS, 'metadatahash', {from: owner});
+                    'Some Name2', 'SON2', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner});
 
                 let count = await factory.getIssuanceCount(true, false, false, false);
                 assert(count.eq(2), count.toNumber().toString());
@@ -908,7 +960,7 @@ contract('IssuanceFactory', (accounts) => {
 
                 await factory.createIssuance(
                     now + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2,
-                    'Some Name3', 'SON3', 18, CC_MAX_TOKENS, 'metadatahash', {from: owner});
+                    'Some Name3', 'SON3', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner});
 
                 count = await factory.getIssuanceCount(true, false, true, true);
                 assert(count.eq(3), count.toNumber().toString());
@@ -920,7 +972,7 @@ contract('IssuanceFactory', (accounts) => {
 
                 await factory.createIssuance(
                     now + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2,
-                    'Some Name4', 'SON4', 18, CC_MAX_TOKENS, 'metadatahash', {from: owner});
+                    'Some Name4', 'SON4', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner});
 
                 count = await factory.getIssuanceCount(true, false, false, false);
                 assert(count.eq(1), count.toNumber().toString());
@@ -1041,7 +1093,7 @@ contract('IssuanceFactory', (accounts) => {
             it('should return correct number of issuances when running two issuances simultaneously', async () => {
                 await factory.createIssuance(
                     now + 2 * SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2,
-                    'Some Name2', 'SON2', 18, CC_MAX_TOKENS, 'metadatahash', {from: owner});
+                    'Some Name2', 'SON2', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner});
 
                 let issuanceIds = await factory.getIssuanceIds(true, false, false, false, 0, 10);
                 assert.equal(issuanceIds.length, 2);
@@ -1095,7 +1147,7 @@ contract('IssuanceFactory', (accounts) => {
 
                 await factory.createIssuance(
                     now + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2,
-                    'Some Name3', 'SON3', 18, CC_MAX_TOKENS, 'metadatahash', {from: owner});
+                    'Some Name3', 'SON3', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner});
 
                 issuanceIds = await factory.getIssuanceIds(true, false, true, true, 0, 10);
                 assert.equal(issuanceIds.length, 3);
@@ -1107,7 +1159,7 @@ contract('IssuanceFactory', (accounts) => {
 
                 await factory.createIssuance(
                     now + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2,
-                    'Some Name4', 'SON4', 18, CC_MAX_TOKENS, 'metadatahash', {from: owner});
+                    'Some Name4', 'SON4', 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner});
 
                 issuanceIds = await factory.getIssuanceIds(true, false, false, false, 0, 10);
                 assert.equal(issuanceIds.length, 1);
@@ -1127,7 +1179,7 @@ contract('IssuanceFactory', (accounts) => {
                     for (let i = 0; i < 19; i++) {
                         const tokenAddressTmp = (await factory.createIssuance(
                             now + SALE_TIME_TILL_START, SALE_DURATION_TIME, THOUSAND_CLN, THOUSAND_CLN / 2,
-                            `Some Name ${i}`, `SON${i}`, 18, CC_MAX_TOKENS, 'metadatahash', {from: owner})).logs[0].args.token;
+                            `Some Name ${i}`, `SON${i}`, 18, CC_MAX_TOKENS, 'ipfs://hash', {from: owner})).logs[0].args.token;
                         tokenAddressArray.push(tokenAddressTmp)
                     }
                     assert.equal(tokenAddressArray.length, 20);

--- a/test/Ownable.js
+++ b/test/Ownable.js
@@ -71,16 +71,16 @@ contract('Ownable', (accounts) => {
             assert.lengthOf(result.logs, 1);
             let event = result.logs[0];
             assert.equal(event.event, 'OwnershipRequested');
-            assert.equal(event.args._by, owner);
-            assert.equal(event.args._to, newOwner);
+            assert.equal(event.args.by, owner);
+            assert.equal(event.args.to, newOwner);
 
             result = await ownable.acceptOwnership({from: newOwner});
 
             assert.lengthOf(result.logs, 1);
             event = result.logs[0];
             assert.equal(event.event, 'OwnershipTransferred');
-            assert.equal(event.args._from, owner);
-            assert.equal(event.args._to, newOwner);
+            assert.equal(event.args.from, owner);
+            assert.equal(event.args.to, newOwner);
         });
     });
 });

--- a/truffle.js
+++ b/truffle.js
@@ -5,6 +5,12 @@ module.exports = {
       port: 8545,
       network_id: "*", // Match any network id
       gas: 8000029
+    },
+    migrations: {
+      host: "localhost",
+      port: 8545,
+      network_id: "3", // Match any network id
+      gas: 4000029
     }
   },
   mocha: {

--- a/truffle.js
+++ b/truffle.js
@@ -1,24 +1,24 @@
 module.exports = {
   networks: {
     development: {
-      host: "localhost",
+      host: 'localhost',
       port: 8545,
-      network_id: "*", // Match any network id
+      network_id: '*', // Match any network id
       gas: 8000029
     },
-    migrations: {
-      host: "localhost",
+    ropsten: {
+      host: 'localhost',
       port: 8545,
-      network_id: "3", // Match any network id
+      network_id: '3',
       gas: 4000029
     }
   },
   mocha: {
-  	//grep: "presaleAllocation"
+    //grep: 'presaleAllocation'
   },
   rpc: {
-    host: "localhost",
-    gas: 8000029 ,
+    host: 'localhost',
+    gas: 8000029,
     port: 8545
   },
   solc: {
@@ -27,4 +27,4 @@ module.exports = {
       runs: 200
     }
   }
-};
+}


### PR DESCRIPTION
- [x] Adding the tokenURI field to the CC
- [x] Writing tests
- [x] Make a demo for the dApp

from EIP721:

A mechanism is provided to associate NFTs with URIs. We expect that many implementations will take advantage of this to provide metadata for each NFT. The image size recommendation is taken from Instagram, they probably know much about image usability. **The URI MAY be mutable (i.e. it changes from time to time). We considered an NFT representing ownership of a house, in this case metadata about the house (image, occupants, etc.) can naturally change.**

